### PR TITLE
Make name parameter optional on `ls` command

### DIFF
--- a/src/Meanbee/Magedbm/Command/ListCommand.php
+++ b/src/Meanbee/Magedbm/Command/ListCommand.php
@@ -61,9 +61,20 @@ class ListCommand extends BaseCommand
                 array('Bucket' => $config['bucket'], 'Prefix' => $name)
             );
 
+            $names = array();
             foreach ($results as $item) {
                 $itemKeyChunks = explode('/', $item['Key']);
-                $this->getOutput()->writeln(sprintf('%s %dMB', array_pop($itemKeyChunks), $item['Size'] / 1024 / 1024));
+
+                if ($name) {
+                    // If name presented, show downloads for that name
+                    $this->getOutput()->writeln(sprintf('%s %dMB', array_pop($itemKeyChunks), $item['Size'] / 1024 / 1024));
+                } else {
+                    // Otherwise show uniqued list of available names
+                    if (!in_array($itemKeyChunks[0], $names)) {
+                        $names[] = $itemKeyChunks[0];
+                        $this->getOutput()->writeln($itemKeyChunks[0]);
+                    }
+                }
             }
 
             if (!$results->count()) {

--- a/src/Meanbee/Magedbm/Command/ListCommand.php
+++ b/src/Meanbee/Magedbm/Command/ListCommand.php
@@ -22,7 +22,7 @@ class ListCommand extends BaseCommand
             ->setDescription('List available backups')
             ->addArgument(
                 'name',
-                InputArgument::REQUIRED,
+                InputArgument::OPTIONAL,
                 'Project identifier'
             )
             ->addOption(
@@ -53,10 +53,12 @@ class ListCommand extends BaseCommand
         $s3 = $this->getS3Client($input->getOption('region'));
         $config = $this->getConfig($input);
 
+        $name = $input->getArgument('name') ? : '';
+
         try {
             $results = $s3->getIterator(
                 'ListObjects',
-                array('Bucket' => $config['bucket'], 'Prefix' => $input->getArgument('name'))
+                array('Bucket' => $config['bucket'], 'Prefix' => $name)
             );
 
             foreach ($results as $item) {

--- a/src/Meanbee/Magedbm/Command/ListCommand.php
+++ b/src/Meanbee/Magedbm/Command/ListCommand.php
@@ -53,7 +53,7 @@ class ListCommand extends BaseCommand
         $s3 = $this->getS3Client($input->getOption('region'));
         $config = $this->getConfig($input);
 
-        $name = $input->getArgument('name') ? : '';
+        $name = $input->getArgument('name') ?: '';
 
         try {
             $results = $s3->getIterator(


### PR DESCRIPTION
When no name provided, rather than outputting every file, take the project names and unique them so that the strings outputted exactly match the names that can be passed in as arguments. 
