### PR TITLE
Fixes #29: Maintaining history function now checks for exact project name

### DIFF
--- a/src/Meanbee/Magedbm/Command/PutCommand.php
+++ b/src/Meanbee/Magedbm/Command/PutCommand.php
@@ -123,7 +123,7 @@ class PutCommand extends BaseCommand
         try {
             $results = $s3->getIterator(
                 'ListObjects',
-                array('Bucket' => $config['bucket'], 'Prefix' => $input->getArgument('name'), 'sort_results' => true)
+                array('Bucket' => $config['bucket'], 'Prefix' => $input->getArgument('name') . '/', 'sort_results' => true)
             );
 
             $results = iterator_to_array($results, true);


### PR DESCRIPTION
It does this by appending '/' to match the exact S3 'folder'

I thought about changing the 'list' command too but decided to leave it to continue to overmatch for usability.
