### PR TITLE
Include 2 decimals in downloads filesize list

### DIFF
--- a/src/Meanbee/Magedbm/Command/ListCommand.php
+++ b/src/Meanbee/Magedbm/Command/ListCommand.php
@@ -65,9 +65,15 @@ class ListCommand extends BaseCommand
             foreach ($results as $item) {
                 $itemKeyChunks = explode('/', $item['Key']);
 
+                // If name presented, show downloads for that name
                 if ($name) {
-                    // If name presented, show downloads for that name
-                    $this->getOutput()->writeln(sprintf('%s %dMB', array_pop($itemKeyChunks), $item['Size'] / 1024 / 1024));
+                    // Get file size in MB
+                    $fileSize = $item['Size'] / 1024 / 1024;
+
+                    // If file size is less than 1MB display 1 decimal place
+                    $fileSize = ($fileSize < 1) ? round($fileSize, 1) : round($fileSize);
+
+                    $this->getOutput()->writeln(sprintf('%s %sMB', array_pop($itemKeyChunks), $fileSize));
                 } else {
                     // Otherwise show uniqued list of available names
                     if (!in_array($itemKeyChunks[0], $names)) {


### PR DESCRIPTION
Not sure if you guys are still maintaining this but I noticed that running the `magedbm ls name` command displays 0MB for all files if they're smaller than 1MB, I'm changed it to display 2 decimals  to make it a bit more useful.
