### PR TITLE
Use signature version 4 for authenticating with S3

### DIFF
--- a/src/Meanbee/Magedbm/Command/BaseCommand.php
+++ b/src/Meanbee/Magedbm/Command/BaseCommand.php
@@ -119,7 +119,8 @@ class BaseCommand extends Command
             try {
                 // Upload to S3.
                 $this->s3Client = S3Client::factory(array(
-                    'region' => $region
+                    'region' => $region,
+                    'signature' => 'v4'
                 ));
             } catch (CredentialsException $e) {
                 $this->getOutput()->writeln('<error>AWS credentials failed</error>');


### PR DESCRIPTION
Fix issue where when attempting to communicate with a bucket in eu-west-2, the correct signature version is not being used.

AWS Regions before January 30 2014 support versions lower than 4, but the London region was added on December 13 2016.

https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html